### PR TITLE
Rename members of Fairing API

### DIFF
--- a/KSP2Runtime/KSPVessel/KSPVesselModule.ModuleFairing.cs
+++ b/KSP2Runtime/KSPVessel/KSPVesselModule.ModuleFairing.cs
@@ -27,10 +27,10 @@ namespace KontrolSystem.KSP.Runtime.KSPVessel {
                 }
             }
 
-            [KSField] public bool IsDeployed => dataFairing.IsDeployed.GetValue();
+            [KSField] public bool IsJettisoned => dataFairing.IsDeployed.GetValue();
 
             [KSMethod]
-            public bool PerformJettison() {
+            public bool Jettison() {
 
                 if (!KSPContext.CurrentContext.Game.SpaceSimulation.TryGetViewObject(part.SimulationObject,
                         out var viewObject)) return false;


### PR DESCRIPTION
Renamed IsDeployed to IsJettisoned (as IsDeployed was confusing and did not have an obvious connection to PerformJettison)
Renamed PerformJettison to Jettison (as the action is called Jettison in-game)

(also Decoupler has IsDecoupled/Decouple, LaunchClamp has IsReleased/Release)