### PR TITLE
resolve type imports

### DIFF
--- a/Tools/vscode/to2-syntax/server/src/to2/ast/to2-module.ts
+++ b/Tools/vscode/to2-syntax/server/src/to2/ast/to2-module.ts
@@ -85,7 +85,7 @@ export class TO2ModuleNode implements Node, TO2Module {
   }
 
   public findType(name: string): TO2Type | undefined {
-    return undefined;
+    return this.types.get(name)?.type
   }
 
   public allTypes(): [string, TO2Type][] {


### PR DESCRIPTION
I don't know if this is all there is to it but this makes imports from local modules such as 

```
use { MyType} from to2Local::mymodule
```

work in the LSP server