### PR TITLE
update throttle control from mainThrottle to wheelThrottle in WheelTh…

### DIFF
--- a/KSP2Runtime/KSPControl/KSPControlModule.WheelThrottleManager.cs
+++ b/KSP2Runtime/KSPControl/KSPControlModule.WheelThrottleManager.cs
@@ -29,9 +29,9 @@ public partial class KSPControlModule {
 
         public override void UpdateAutopilot(ref FlightCtrlState c, float deltaT) {
             if (suspended)
-                c.mainThrottle = 0;
+                c.wheelThrottle = 0;
             else
-                c.mainThrottle = (float)DirectBindingMath.Clamp(wheelThrottleProvider(deltaT), -1, 1);
+                c.wheelThrottle = (float)DirectBindingMath.Clamp(wheelThrottleProvider(deltaT), -1, 1);
         }
     }
 }


### PR DESCRIPTION
fixes the issue of WheelThrottleManager updating the main throttle instead of controlling the wheel throttle. 

```
let manager = vessel.set_wheel_throttle(1.0)
``` 

I tested with a simple rover and I was able to control throttle of the wheels attached to the vessel. 